### PR TITLE
refactor: remove DATABASE_URL check from drizzle.ts

### DIFF
--- a/lib/db/drizzle.ts
+++ b/lib/db/drizzle.ts
@@ -2,7 +2,7 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import * as schema from "./schema";
 
-// For now, let's comment this out to avoir a build error in the automated environment (e.g a GH actions)
+// For now, let's comment this out to avoid a build error in the automated environment (e.g a GH actions)
 // if (!process.env.DATABASE_URL) {
 //   throw new Error("DATABASE_URL environment variable is not set");
 // }

--- a/lib/db/drizzle.ts
+++ b/lib/db/drizzle.ts
@@ -2,6 +2,11 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import * as schema from "./schema";
 
+// For now, let's comment this out to avoir a build error in the automated environment (e.g a GH actions)
+// if (!process.env.DATABASE_URL) {
+//   throw new Error("DATABASE_URL environment variable is not set");
+// }
+
 const globalForDb = globalThis as unknown as {
   conn: postgres.Sql | undefined;
 };

--- a/lib/db/drizzle.ts
+++ b/lib/db/drizzle.ts
@@ -2,10 +2,6 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import * as schema from "./schema";
 
-if (!process.env.DATABASE_URL) {
-  throw new Error("DATABASE_URL environment variable is not set");
-}
-
 const globalForDb = globalThis as unknown as {
   conn: postgres.Sql | undefined;
 };


### PR DESCRIPTION
```bash
if (!process.env.DATABASE_URL) {
   throw new Error("DATABASE_URL environment variable is not set");
}
```

For now, let's comment this out to avoid a build error in the automated environment (e.g a GH actions)